### PR TITLE
Use develop branch for badges [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 An attempt to create a pythonic version of X-Pipeline: https://trac.ligo.caltech.edu/xpipeline/
 
 
-[![Build Status](https://travis-ci.org/X-Pypeline/X-Pypeline.svg?branch=master)](https://travis-ci.org/X-Pypeline/X-Pypeline)
-[![Coverage Status](https://coveralls.io/repos/github/X-Pypeline/X-Pypeline/badge.svg?branch=master)](https://coveralls.io/github/X-Pypeline/X-Pypeline?branch=master)
+[![Build Status](https://travis-ci.org/X-Pypeline/X-Pypeline.svg?branch=develop)](https://travis-ci.org/X-Pypeline/X-Pypeline)
+[![Coverage Status](https://coveralls.io/repos/github/X-Pypeline/X-Pypeline/badge.svg?branch=develop)](https://coveralls.io/github/X-Pypeline/X-Pypeline?branch=develop)


### PR DESCRIPTION
This PR modifies the readme to show the badges from the `develop` branch.